### PR TITLE
Build on armhf without libogre-next-2.3

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -18,7 +18,7 @@ Build-Depends: cmake,
                libgz-plugin2-dev,
                libgz-utils2-dev,
                libogre-1.9-dev,
-               libogre-next-2.3-dev,
+               libogre-next-2.3-dev [!armhf],
                libvulkan-dev
 Vcs-Browser: https://github.com/gazebosim/gz-rendering
 Vcs-Git: https://github.com/gazebo-release/gz-rendering8-release
@@ -110,7 +110,7 @@ Depends: libgz-cmake3-dev,
          libgz-common5-graphics-dev,
          libgz-math7-dev,
          libgz-math7-eigen3-dev,
-         libogre-next-2.3-dev,
+         libogre-next-2.3-dev [!armhf],
          libvulkan-dev,
          libgz-plugin2-dev,
          libgz-rendering8-core-dev (= ${binary:Version}),

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -102,7 +102,7 @@ Description: Gazebo Rendering classes and functions for robot apps - Ogre1 lib
  Ogre1 component shared library
 
 Package: libgz-rendering8-ogre2-dev
-Architecture: any
+Architecture: amd64 arm64
 Section: libdevel
 Depends: libgz-cmake3-dev,
          libgz-common5-events-dev,

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -128,7 +128,7 @@ Description: Gazebo Rendering classes and functions for robot apps - Development
  Ogre2 component development files
 
 Package: libgz-rendering8-ogre2
-Architecture: any
+Architecture: amd64 arm64
 Section: libdevel
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: same


### PR DESCRIPTION
Fine tuning the packaging to avoid ogre-next which is not available on `armhf`:

https://build.osrfoundation.org/job/ogre-2.3-debbuilder/60/consoleFull#-13143130476ea37b8d-a6d4-40ae-8431-d90c018842af
```
  360 |     "settings. You can also manually set OGRE_DEBUG_MODE to either 1 or 0 instead of adding _DEBUG." )
      |                                                                                                      ^
/home/jenkins/workspace/ogre-2.3-debbuilder/repo/RenderSystems/Vulkan/src/OgreVulkanRenderSystem.cpp: In member function ‘virtual void Ogre::VulkanRenderSystem::_hlmsSamplerblockDestroyed(Ogre::HlmsSamplerblock*)’:
/home/jenkins/workspace/ogre-2.3-debbuilder/repo/RenderSystems/Vulkan/src/OgreVulkanRenderSystem.cpp:3371:36: error: invalid ‘static_cast’ from type ‘void*’ to type ‘VkSampler’ {aka ‘long long unsigned int’}
 3371 |         VkSampler textureSampler = static_cast<VkSampler>( block->mRsData );
      |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[4]: *** [RenderSystems/Vulkan/CMakeFiles/RenderSystem_Vulkan.dir/build.make:373: RenderSystems/Vulkan/CMakeFiles/RenderSystem_Vulkan.dir/src/OgreVulkanRenderSystem.cpp.o] Error 1
make[4]: Leaving directory '/home/jenkins/workspace/ogre-2.3-debbuilder/repo/obj-arm-linux-gnueabihf'
make[3]: *** [CMakeFiles/Makefile2:465: RenderSystems/Vulkan/CMakeFiles/RenderSystem_Vulkan.dir/all] Error 2
make[3]: *** Waiting for unfinished jobs....
```

Tested: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-rendering8-debbuilder&build=563)](https://build.osrfoundation.org/job/gz-rendering8-debbuilder/563/)